### PR TITLE
Prevent users from not selecting a commit

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/pipeline_operations_widget.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/pipeline_operations_widget.js.msx
@@ -96,6 +96,15 @@ export const PipelineOperationsWidget = {
       return "There was an unknown error.";
     };
 
+    const isRevisionSelected = (triggerWithOptionsInfo) => {
+      for (const m of triggerWithOptionsInfo.materials) {
+        if (m.isRevisionSelected()) {
+          return true;
+        }
+      }
+      return false;
+    };
+
     self.destroyPausePopup = (modal) => {
       self.pauseMessage("");
       modal.destroy();
@@ -137,8 +146,13 @@ export const PipelineOperationsWidget = {
               class:   'save primary',
               onclick: () => {
                 const isValid = self.triggerWithOptionsInfo().validate();
+                const isSelected = isRevisionSelected(self.triggerWithOptionsInfo());
 
-                if (isValid) {
+                if (!isSelected) {
+                  console.error('Dev-Infra: We require users to select a revision/deployment when manually running a pipeline, otherwise the previous pipeline run is re-run instead of using the latest material.');
+                  self.errorMessage(`You must select a revision/deployment to trigger the ${pipeline.name} pipeline.`);
+                  m.redraw();
+                } else if (isValid) {
                   self.trigger(pipeline, self.triggerWithOptionsInfo().getTriggerOptionsJSON());
                   onModalClose();
                 } else {

--- a/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/trigger_with_options/modal_body.js.msx
+++ b/server/src/main/webapp/WEB-INF/rails/webpack/views/dashboard/trigger_with_options/modal_body.js.msx
@@ -34,7 +34,7 @@ export const ModalBody = {
 
 
   view(vnode) {
-    let secureVarsTabContent, environmentVarsTabContent, secureVarsTab, environmentVarsTab;
+    let secureVarsTabContent, environmentVarsTabContent, secureVarsTab, environmentVarsTab, messageContent;
 
     const self    = vnode.state;
     const vm      = vnode.attrs.vm();
@@ -50,6 +50,8 @@ export const ModalBody = {
           <div class="page-spinner"/>
         </div>
       );
+    } else if (message()) {
+      messageContent = (<f.alert>{message()}</f.alert>);
     }
 
     const materialsKey = vm.MATERIALS_TAB_KEY;
@@ -89,6 +91,8 @@ export const ModalBody = {
 
     return (
       <div class="h-tab pipeline-trigger-with-options">
+        {messageContent}
+
         <ul class="h-tab_tab-head pipeline_options-heading">
           <li class={self.visibilityClassForTab(materialsKey)}
               onclick={vm.selectTab.bind(vm, materialsKey)}>


### PR DESCRIPTION
This will show an error message to the user if they don't select a commit. This prevents users from thinking they are deploying the latest material instead of the previous pipeline runs material.

![Screenshot from 2023-08-17 11-58-23](https://github.com/getsentry/gocd/assets/112419115/1d3a64d1-6c8e-4228-876c-90d0f3cdcf1c)
