### PR TITLE
Adding retry mechanism to git fetch

### DIFF
--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
@@ -272,8 +272,9 @@ public class GitCommand extends SCMCommand {
             if (result == 0) {
                 break;
             }
-            log(outputStreamConsumer, "Fetch attempt %d of %d failed. Retrying...", attempt + 1, MAX_RETRIES);
+            log(outputStreamConsumer, "Fetch attempt %d of %d failed", attempt + 1, MAX_RETRIES);
             if (attempt < MAX_RETRIES - 1) {
+                log(outputStreamConsumer, "Waiting %d seconds before retrying", RETRY_SLEEP / 1000);
                 try {
                     Thread.sleep(RETRY_SLEEP);
                 } catch (InterruptedException e) {


### PR DESCRIPTION
Currently we are having issues with git fetch failing intermittently. Recently it has started to happen more and has finally become enough of a problem that we want to address it. This PR aims to mitigate the problem by retrying git fetch up to three times (with a small 5 second delay between each attempt). If this is truly a transitive and intermittent issue, this should greatly reduce the amount of failures attributed to it.