### PR TITLE
fix permissions and use a tempdir

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,21 @@
 https://developer.gocd.org/current/
 
-brew install openjdk@17
+`brew install node@20 yarn openjdk@17`
+
+note: node@20 is important because later versions of node don't work as they disallow directory imports... this is probably fixed if we update gocd
+
+make sure docker-buildx is also installed:
+`brew install docker-buildx`
+
+and in `~/.config/docker.json`:
+
+```
+{
+	"cliPluginsExtraDirs": [
+	    "/opt/homebrew/lib/docker/cli-plugins"
+	]
+}
+```
 
 # fastest dev loop for compile errors
 cd server/src/main/webapp/WEB-INF/rails && yarn run webpack-watch
@@ -9,7 +24,11 @@ cd server/src/main/webapp/WEB-INF/rails && yarn run webpack-watch
 # template: buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
 # output: docker/gocd-server/target/alpine-3.18/docker-gocd-server/Dockerfile
 # ./gradlew serverGenericZip
-./gradlew -PdockerBuildLocalZip :docker:gocd-server:alpine-3.18:docker
+
+
+```
+PATH=/opt/homebrew/opt/openjdk@17/bin:/opt/homebrew/opt/node@20/bin:$PATH ./gradlew -PdockerBuildLocalZip :docker:gocd-server:alpine-3.18:docker
+```
 
 # dev
 # for the fastest UI testing workflow, overwrite latest, then you just delete server pods to get them to recreate

--- a/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
+++ b/buildSrc/src/main/resources/gocd-docker-server/Dockerfile.server.ftl
@@ -92,9 +92,9 @@ RUN \
 </#list>
   mkdir -p /go-server /go-working-dir /godata
 
-ADD docker-entrypoint.sh /
-ADD docker-entrypoint.d /docker-entrypoint.d
-ADD cron /cron
+COPY docker-entrypoint.sh /
+COPY docker-entrypoint.d /docker-entrypoint.d
+COPY cron /cron
 
 # gocd doesn't have the ability to delete old artifacts by date
 # which can result in running low on inodes if there are lots of pipelines
@@ -108,8 +108,8 @@ COPY --from=gocd-server-unzip /go-server /go-server
 COPY --chown=go:root logback-include.xml /go-server/config/logback-include.xml
 COPY --chown=go:root install-gocd-plugins git-clone-config /usr/local/sbin/
 
-RUN chown -R go:root /docker-entrypoint.d /go-working-dir /godata /docker-entrypoint.sh && \
-    chmod -R g=u /docker-entrypoint.d /go-working-dir /godata /docker-entrypoint.sh
+RUN chown -R go:root /docker-entrypoint.d /go-working-dir /godata /cron /docker-entrypoint.sh && \
+    chmod -R g=u /docker-entrypoint.d /go-working-dir /godata /cron /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/buildSrc/src/main/resources/gocd-docker-server/cron/cleanup-old-artifacts.sh
+++ b/buildSrc/src/main/resources/gocd-docker-server/cron/cleanup-old-artifacts.sh
@@ -11,6 +11,8 @@ HERE="$(dirname "$0")"
 PATH="$PATH:$HOME/prefix/google-cloud-sdk/bin"
 dest="$tf_backup_bucket/gocd-artifact-archive"
 
+tmpdir="$(mktemp -d)"
+
 main() {
     set -x
 
@@ -22,15 +24,16 @@ main() {
     # /godata/artifacts/pipelines/example/9388/deploy-primary/1/deploy/cruise-output/console.log
     # and just having /godata/artifacts/pipelines/example/9388 makes things go a lot faster
     dt="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-    /bin/busybox find /godata/artifacts/pipelines/ -maxdepth 2 -type d -mtime +30 -print > dirs.txt
-    /bin/busybox tar c -z -f "${dt}.tgz" -T dirs.txt
+    /bin/busybox find /godata/artifacts/pipelines/ -maxdepth 2 -type d -mtime +30 -print > "{tmpdir}/dirs.txt"
+    /bin/busybox tar c -z -f "${dt}.tgz" -T "{tmpdir}/dirs.txt"
 
     # gsutil is deprecated: https://cloud.google.com/storage/docs/gsutil#should-you-use
     : "Uploading to GCS bucket ${dest}."
     gcloud storage cp "${dt}.tgz" "${dest}/${dt}.tgz" && rm "${dt}.tgz"
 
     : "Deleting from disk:"
-    xargs rm -rv < dirs.txt
+    xargs rm -rv < "{tmpdir}/dirs.txt"
+    rm -rf "tmpdir"
 }
 
 main "$@"


### PR DESCRIPTION
should fix https://getsentry.atlassian.net/browse/DEVINFRA-640

crond is running as go, which doesn’t have permissions to write to /cron/dirs.txt:
```
 /cron/cleanup-old-artifacts.sh: line 25: dirs.txt: Permission denied
```

That was bad anyways, should be using a tempdir since it's more hygenic and no clobbering potential.
