### PR TITLE
chore: bump jitpack jruby version

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -89,7 +89,7 @@ final Map<String, String> libraries = [
   oshi                : 'com.github.oshi:oshi-core-java11:6.8.0',
   postgresql          : 'org.postgresql:postgresql:42.7.5',
   quartz              : 'org.quartz-scheduler:quartz:2.5.0',
-  rack                : 'com.github.gocd-contrib:jruby-rack:1.2.3.7',
+  rack                : 'com.github.gocd-contrib:jruby-rack:1.2.4.1',
   resilience4jRetry   : 'io.github.resilience4j:resilience4j-retry:2.3.0',
   semanticVersion     : 'de.skuzzle:semantic-version:2.1.1',
   servletApi          : 'jakarta.servlet:jakarta.servlet-api:4.0.4', // Should be compatible with Jetty and Spring implementations


### PR DESCRIPTION
Our GoCD server cloud build fails as the `jruby-rack` 1.2.3.7 artifact is no longer available on JitPack. 
<img width="1136" height="378" alt="Screenshot 2026-02-10 at 4 25 47 PM" src="https://github.com/user-attachments/assets/3d294703-67cd-4e3d-9c50-a950111a8871" />

<img width="716" height="113" alt="Screenshot 2026-02-10 at 4 25 34 PM" src="https://github.com/user-attachments/assets/c7aff103-82be-4f68-babc-23c1ffabe42a" />

Let's bump to the latest minor version release (1.2.4.1 -- this is available at https://jitpack.io/com/github/gocd-contrib/jruby-rack/1.2.3.7/jruby-rack-1.2.3.7.jar).