### PR TITLE
fix: upgrade svgo to 2.8.1+ to address CVE-2026-29074

### DIFF
--- a/server/src/main/webapp/WEB-INF/rails/package.json
+++ b/server/src/main/webapp/WEB-INF/rails/package.json
@@ -131,7 +131,8 @@
     "webpack@npm:4.47.0/terser-webpack-plugin": "^4.2.3",
     "terser-webpack-plugin@npm:4.2.3/serialize-javascript": "^6.0.2",
     "watchpack-chokidar2@npm:2.0.1/chokidar": "^3.6.0",
-    "karma-jasmine@npm:5.1.0/jasmine-core": "^5.1.1"
+    "karma-jasmine@npm:5.1.0/jasmine-core": "^5.1.1",
+    "svgo": "^2.8.1"
   },
   "packageManager": "yarn@4.7.0"
 }

--- a/server/src/main/webapp/WEB-INF/rails/yarn.lock
+++ b/server/src/main/webapp/WEB-INF/rails/yarn.lock
@@ -1527,13 +1527,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@trysound/sax@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@trysound/sax@npm:0.2.0"
-  checksum: 10/7379713eca480ac0d9b6c7b063e06b00a7eac57092354556c81027066eb65b61ea141a69d0cc2e15d32e05b2834d4c9c2184793a5e36bbf5daf05ee5676af18c
-  languageName: node
-  linkType: hard
-
 "@tsconfig/node10@npm:^1.0.7":
   version: 1.0.11
   resolution: "@tsconfig/node10@npm:1.0.11"
@@ -9690,6 +9683,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sax@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "sax@npm:1.5.0"
+  checksum: 10/9012ff37dda7a7ac5da45db2143b04036103e8bef8d586c3023afd5df6caf0ebd7f38017eee344ad2e2247eded7d38e9c42cf291d8dd91781352900ac0fd2d9f
+  languageName: node
+  linkType: hard
+
 "schema-utils@npm:2.7.0":
   version: 2.7.0
   resolution: "schema-utils@npm:2.7.0"
@@ -10682,20 +10682,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"svgo@npm:^2.7.0":
-  version: 2.8.0
-  resolution: "svgo@npm:2.8.0"
+"svgo@npm:^2.8.1":
+  version: 2.8.2
+  resolution: "svgo@npm:2.8.2"
   dependencies:
-    "@trysound/sax": "npm:0.2.0"
     commander: "npm:^7.2.0"
     css-select: "npm:^4.1.3"
     css-tree: "npm:^1.1.3"
     csso: "npm:^4.2.0"
     picocolors: "npm:^1.0.0"
+    sax: "npm:^1.5.0"
     stable: "npm:^0.1.8"
   bin:
-    svgo: bin/svgo
-  checksum: 10/2b74544da1a9521852fe2784252d6083b336e32528d0e424ee54d1613f17312edc7020c29fa399086560e96cba42ede4a2205328a08edeefa26de84cd769a64a
+    svgo: ./bin/svgo
+  checksum: 10/a0922a2cbbbc51c0162ea7a7d6c5b660fb4fb65e0f05e226ba571cfe8b651fd870072aed2722ef96715fb77829562b351eb72f2b7bf09038ffc88969acaffd0f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Fixes CVE-2026-29074: SVGO Billion Laughs (XML entity expansion) denial-of-service vulnerability (CVSS 7.5 HIGH)
- `svgo@2.8.0` is a transitive dependency via `optimize-css-assets-webpack-plugin` → `cssnano` → `postcss-svgo` → `svgo`
- Adds a yarn resolution in `package.json` to pin `svgo >= 2.8.1`, which properly restricts XML entity expansion
- Yarn resolved to `svgo@2.8.2`

## Test plan
- [x] `yarn install` completes successfully with the new resolution
- [ ] Verify GoCD server UI builds correctly with the updated dependency

DI-1701

Co-Authored-By: Claude [noreply@anthropic.com](mailto:noreply@anthropic.com)