### PR TITLE
chore: revert XXE fix in GoConfigService SAXReader (#18)

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/GoConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/GoConfigService.java
@@ -954,14 +954,6 @@ public class GoConfigService implements Initializer, CruiseConfigProvider {
         protected XmlPartialSaver(ConfigElementImplementationRegistry registry) {
             this.registry = registry;
             reader = new SAXReader();
-            try {
-                // Securely configure the SAXReader to prevent XXE attacks
-                reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-                reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
-                reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            } catch (org.xml.sax.SAXNotRecognizedException | org.xml.sax.SAXNotSupportedException e) {
-                throw new RuntimeException("Failed to configure SAXReader securely against XXE vulnerabilities", e);
-            }
             reader.setEntityResolver((publicId, systemId) -> new InputSource(new StringReader("")));
         }
 


### PR DESCRIPTION
Reverts #18, which added secure-feature configuration to the `SAXReader` in `GoConfigService` to mitigate XXE. We're rolling that change back; reason to be filled in by the author.

The revert removes the eight added lines in `XmlPartialSaver`, restoring the prior `SAXReader` setup unchanged. No other files are touched.